### PR TITLE
Remove Chacha20+MAC in favour of Chacha20 Poly1305.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Key features and cryptography:
 - [scrypt](https://en.wikipedia.org/wiki/Scrypt)
 [RFC 7914](https://tools.ietf.org/html/rfc7914)
 for the key derivation function
-([KDF](https://en.wikipedia.org/wiki/Key_derivation_function));
-[AES 256](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard) or
+([KDF](https://en.wikipedia.org/wiki/Key_derivation_function)).
+- [AES 256](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard) or
 [Chacha20](https://en.wikipedia.org/wiki/ChaCha20) cipher with
 [AE](https://en.wikipedia.org/wiki/Authenticated_encryption).
 - Authentication with the server using

--- a/src/crypto/crypto.c
+++ b/src/crypto/crypto.c
@@ -47,14 +47,11 @@ static const struct {
 	const char *		name;
 	crypto_cipher_t		id;
 } cipher_str2id[] = {
-	{ "aes-256-gcm",	AES_256_GCM		},
-	{ "chacha20-poly1305",	CHACHA20_POLY1305	},
 #if !defined(USE_AE_CIPHERS_ONLY)
 	{ "aes-256-cbc",	AES_256_CBC		},
-#if 0
-	{ "chacha20",		CHACHA20		},
 #endif
-#endif
+	{ "aes-256-gcm",	AES_256_GCM		},
+	{ "chacha20-poly1305",	CHACHA20_POLY1305	},
 	{ NULL,			CIPHER_NONE		},
 };
 

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -21,7 +21,7 @@ typedef enum {
 	CIPHER_NONE		= 0,
 	AES_256_CBC		= 1,
 	AES_256_GCM		= 2,
-	CHACHA20		= 3,
+	CIPHER_RESERVED0	= 3,
 	CHACHA20_POLY1305	= 4,
 } crypto_cipher_t;
 

--- a/src/crypto/mbedtls.c
+++ b/src/crypto/mbedtls.c
@@ -29,8 +29,6 @@ get_mbedtls_cipher(crypto_cipher_t c)
 		return MBEDTLS_CIPHER_AES_256_CBC;
 	case AES_256_GCM:
 		return MBEDTLS_CIPHER_AES_256_GCM;
-	case CHACHA20:
-		return MBEDTLS_CIPHER_CHACHA20;
 	case CHACHA20_POLY1305:
 		return MBEDTLS_CIPHER_CHACHA20_POLY1305;
 	default:
@@ -98,7 +96,6 @@ mbedtls_crypto_encrypt(const crypto_t *crypto,
 
 	switch (crypto->cipher) {
 	case AES_256_CBC:
-	case CHACHA20:
 		ret = mbedtls_cipher_crypt(ctx, crypto->iv, crypto->ilen,
 		    inbuf, inlen, outbuf, &nbytes);
 		break;
@@ -134,7 +131,6 @@ mbedtls_crypto_decrypt(const crypto_t *crypto,
 
 	switch (crypto->cipher) {
 	case AES_256_CBC:
-	case CHACHA20:
 		ret = mbedtls_cipher_crypt(ctx, crypto->iv, crypto->ilen,
 		    inbuf, inlen, outbuf, &nbytes);
 		break;

--- a/src/crypto/openssl.c
+++ b/src/crypto/openssl.c
@@ -43,9 +43,6 @@ get_openssl_cipher(crypto_cipher_t c)
 	case AES_256_GCM:
 		cipher = EVP_aes_256_gcm();
 		break;
-	case CHACHA20:
-		cipher = EVP_chacha20();
-		break;
 	case CHACHA20_POLY1305:
 		/* Note: OpenSSL uses IETF (RFC 7539) variation. */
 		cipher = EVP_chacha20_poly1305();
@@ -76,10 +73,6 @@ openssl_crypto_create(crypto_t *crypto)
 		 * Both ciphers use 128-bit authentication tag.
 		 */
 		crypto->tlen = 16;
-		break;
-	case CHACHA20:
-		/* Override OpenSSL to use 96-bit nonce (RFC 7539). */
-		crypto->ilen = 12;
 		break;
 	default:
 		crypto->tlen = 0;

--- a/src/tests/t_consts.c
+++ b/src/tests/t_consts.c
@@ -20,20 +20,6 @@
 #include "mock.h"
 #include "utils.h"
 
-/*
- * AES 256 + CBC mode: IV is 16 bytes; key is 32 bytes.
- * Chacha20: IV is 16 bytes (96 bit nonce + 32 bit counter); key is 32 bytes.
- *
- * cipher="-aes-256-cbc "
- * cipher="-chacha20"
- *
- * printf "the quick brown fox jumped over the lazy dog" | \
- *   openssl enc $cipher \
- *   -iv 508c39cf1b4a706a219ab837981ba4b0 \
- *   -K 0705b45c2be368b6aadf21656a89dad8fed6172170b7e78f638a650dab05d7ea | \
- *   od -t x1
- */
-
 #define	TEST_KEY \
     "0705b45c2be368b6aadf21656a89dad8fed6172170b7e78f638a650dab05d7ea"
 
@@ -62,19 +48,6 @@ static const struct test_case {
 		    "63 b1 16 66 a8 c6 6e c8 a1 50 18 66 ff e8 87 e5"
 		    "10 f5 4b 3c 6e c2 3e 1a 09 e3 d7 e7 53 f9 b1 61",
 	},
-#if 0
-	{
-		.cipher = CHACHA20,
-		.iv = TEST_IV_96,
-		.exp_aetag =
-		    "4c 3b d9 61 ba e5 61 66 0f fb 50 76 ce 46 29 9e"
-		    "d5 9e d5 2f 2d d7 7f 07 97 36 c5 1d 12 af 96 40",
-		.expecting =
-		    "74 71 33 58 54 5a 74 1f 25 f1 13 85 6b fd ca 15"
-		    "d7 34 5c 4f 80 39 d5 5c ba 0d f8 9a d5 ae b4 98"
-		    "44 49 6d a6 99 8e a3 bb a5 3f 52 97",
-	},
-#endif
 #endif
 	{
 		.cipher = AES_256_GCM,


### PR DESCRIPTION
Test vectors with OpenSSL produce different output on x86_64 and arm64.
OpenSSL and mbedtls also produce different outputs with non-zero IV.
This seems to be due to endianness bugs in one of the libraries and
there is little reason to pursue supporting non-Poly1305 version.