### PR TITLE
src/crypto/crypto.h: fix build with the linux musl libc.

### DIFF
--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -8,6 +8,7 @@
 #ifndef	_CRYPTO_H_
 #define	_CRYPTO_H_
 
+#include <sys/types.h>
 #include <stdint.h>
 #include <stdbool.h>
 


### PR DESCRIPTION
ssize_t is defined in <sys/types.h>.

Build log for x86_64-musl (voidlinux) at:
https://build.voidlinux.org/builders/x86_64-musl_builder/builds/27590/steps/shell_3/logs/stdio

Cheers