### PR TITLE
ssize_t is defined in <sys/types.h>.

### DIFF
--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -8,6 +8,7 @@
 #ifndef	_CRYPTO_H_
 #define	_CRYPTO_H_
 
+#include <sys/types.h>
 #include <stdint.h>
 #include <stdbool.h>
 


### PR DESCRIPTION
Build log for x86_64-musl (voidlinux) at:
https://build.voidlinux.org/builders/x86_64-musl_builder/builds/27590/steps/shell_3/logs/stdio

From xtraeme on Github via #51.  Re-based to re-run the tests.