### PR TITLE
Couple bug fixes and a minor improvement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ Download the latest packages from the [releases](https://github.com/rmind/rvault
 
 ## Usage
 
-Drop us an email to get an assigned UUID. Setup the vault and create the passphrase:
+You need to run [rvault svc](https://github.com/rmind/rvault-svc), the
+server-side service, yourself.
+
+Setup the vault and create the passphrase:
 ```shell
 export RVAULT_SERVER="https://rvault.noxt.eu"
 export RVAULT_PATH="/home/alice/vault"

--- a/src/fuse/rvaultfs.c
+++ b/src/fuse/rvaultfs.c
@@ -148,12 +148,14 @@ rvaultfs_open_raw(const char *path, struct fuse_file_info *fi, mode_t mode)
 static int
 rvaultfs_create(const char *path, mode_t mode, struct fuse_file_info *fi)
 {
+	app_log(LOG_DEBUG, "%s: `%s' mode 0%o", __func__, path, mode);
 	return rvaultfs_open_raw(path, fi, mode);
 }
 
 static int
 rvaultfs_open(const char *path, struct fuse_file_info *fi)
 {
+	app_log(LOG_DEBUG, "%s: `%s'", __func__, path);
 	return rvaultfs_open_raw(path, fi, FOBJ_OMASK);
 }
 
@@ -323,6 +325,7 @@ rvaultfs_chmod(const char *path, mode_t mode)
 		return -errno;
 	}
 	ret = chmod(vpath, mode);
+	app_log(LOG_DEBUG, "%s: path `%s', retval %d", __func__, path, ret);
 	return (ret == -1) ? -errno : ret;
 }
 
@@ -336,6 +339,7 @@ rvaultfs_chown(const char *path, uid_t uid, gid_t gid)
 		return -errno;
 	}
 	ret = chown(vpath, uid, gid);
+	app_log(LOG_DEBUG, "%s: path `%s', retval %d", __func__, path, ret);
 	return (ret == -1) ? -errno : ret;
 }
 
@@ -348,7 +352,8 @@ rvaultfs_utimens(const char *path, const struct timespec ts[2])
 	if (get_vault_path(path, vpath, sizeof(vpath)) == -1) {
 		return -errno;
 	}
-	ret = utimensat(-1, path, ts, AT_SYMLINK_NOFOLLOW);
+	ret = utimensat(-1, vpath, ts, AT_SYMLINK_NOFOLLOW);
+	app_elog(LOG_DEBUG, "%s: path `%s', retval %d", __func__, path, ret);
 	return (ret == -1) ? -errno : ret;
 }
 

--- a/src/rvault.1
+++ b/src/rvault.1
@@ -89,7 +89,7 @@ WARNING: Such use case is very significantly less secure.
 Show help of this command.
 .El
 .\" ---
-.It Ic export-key
+.It Ic export-key Oo Fl s Oc
 Print the metadata and the effective encryption key.
 This command can be used to backup the key and relevant metadata
 for recovery purposes.
@@ -102,6 +102,11 @@ command with the
 .Fl r
 flag.
 The recovery data must be typed back exactly as it was printed.
+.Pp
+Alternatively, the
+.Fl s
+flag can be used for a silent mode (with consent) where the output can be
+redirected directly into a file which would be used as a recovery key.
 .\" ---
 .It Ic ls Oo Fl a Oc Oo Fl h Oc Op path
 List the vault contents.
@@ -211,6 +216,12 @@ export RVAULT_PATH=/home/user/vault
 
 rvault create $UID
 rvault mount /mnt/vault
+.Ed
+.Pp
+Another example on how to create and use the recovery key:
+.Bd -literal -offset indent
+rvault export-key -s > rvault-recovery.key
+rvault mount -r rvault-recovery.key /mnt/vault
 .Ed
 .\" -----
 .Sh SEE ALSO


### PR DESCRIPTION
- fileobj_stat: use lstat() and read the file header to obtain the
  real file size only if it's not-empty.  Reduces the error rate with
  some applications which create files using mode = 0.
- rvaultfs_utimens: pass the vault path.
- export-key command: add -s flag for silent mode; add an example.