### PR TITLE
More file reference (descriptor) handling fixes.

### DIFF
--- a/src/core/fileobj.h
+++ b/src/core/fileobj.h
@@ -14,7 +14,10 @@ typedef struct fileref fileref_t;
 struct fileobj;
 typedef struct fileobj fileobj_t;
 
-enum { FOBJ_WRITEBACK, FOBJ_FULLSYNC };
+enum {
+	FOBJ_WRITEBACK,		// write dirty data to the backing store
+	FOBJ_FULLSYNC		// FOBJ_WRITEBACK + invoke full sync
+};
 
 #define	FOBJ_OMASK	0644	// default file mask
 


### PR DESCRIPTION
- fileobj_alloc: fix the destruction of the object in the error path.
- fileobj_alloc: override the open() flags to support different modes.
- fileobj_close: perform the writeback on descriptor close.