### PR TITLE
Fix build on NetBSD by removing `__NetBSD__` workaround

### DIFF
--- a/src/fuse/rvaultfs.c
+++ b/src/fuse/rvaultfs.c
@@ -510,22 +510,6 @@ rvaultfs_run(rvault_t *vault, const char *mountpoint, bool fg, bool debug)
 	if (debug) {
 		fuse_opt_add_arg(&args, "-odebug");
 	}
-#if defined(__NetBSD__)
-	fuse = fuse_new(&args, &rvaultfs_ops, sizeof(rvaultfs_ops), vault);
-	if (fuse == NULL) {
-		return -1;
-	}
-	if (fuse_mount(fuse, mountpoint) == -1) {
-		fuse_destroy(fuse);
-		return -1;
-	}
-	if (!fg) {
-		(void)fuse_daemonize(fuse);
-	}
-	ret = fuse_loop(fuse);
-	app_log(LOG_DEBUG, "%s: exited fuse_loop() with %d", __func__, ret);
-	fuse_unmount(fuse);
-#else
 	struct fuse_chan *chan;
 
 	if ((chan = fuse_mount(mountpoint, &args)) == NULL) {
@@ -540,7 +524,6 @@ rvaultfs_run(rvault_t *vault, const char *mountpoint, bool fg, bool debug)
 	ret = fuse_loop(fuse);
 	app_log(LOG_DEBUG, "%s: exited fuse_loop() with %d", __func__, ret);
 	fuse_unmount(mountpoint, chan);
-#endif
 	fuse_destroy(fuse);
 	fuse_opt_free_args(&args);
 	return ret;


### PR DESCRIPTION
Remove `__NetBSD__` workaround for old versions of NetBSD librefuse. Here's an explanation why it's problematic:

This filesystem declares that it wants FUSE 2.6 API:
```
#define	FUSE_USE_VERSION	26
```

In the past NetBSD had a broken implementation of FUSE API. It used to expose FUSE 3.0 API even when 2.6 was requested. Since these two versions have incompatible `fuse_new(3)`, `rvaultfs.c` uses FUSE 3.0 API as a workaround. However, NetBSD no longer has this issue and now it correctly exposes FUSE 2.6 API when requested so. Trying to use 3.0 API results in a compilation error.